### PR TITLE
Viewable nameservers and remove static PHP set

### DIFF
--- a/PluginEnhance.php
+++ b/PluginEnhance.php
@@ -134,10 +134,6 @@ class PluginEnhance extends ServerPlugin
         $new_website->setDomain($args['package']['domain_name']);
         $website = $api['websitesClient']->createWebsite($orgId, $new_website);
 
-        $update_website = new \OpenAPI\Client\Model\UpdateWebsite();
-
-        $api['websitesClient']->updateWebsite($orgId, $website['id'], $update_website);
-
         return $userPackage->getCustomField("Domain Name") . ' has been created.';
     }
 

--- a/PluginEnhance.php
+++ b/PluginEnhance.php
@@ -135,7 +135,6 @@ class PluginEnhance extends ServerPlugin
         $website = $api['websitesClient']->createWebsite($orgId, $new_website);
 
         $update_website = new \OpenAPI\Client\Model\UpdateWebsite();
-        $update_website->setPhpVersion(\OpenAPI\Client\Model\PhpVersion::PHP74);
 
         $api['websitesClient']->updateWebsite($orgId, $website['id'], $update_website);
 

--- a/PluginEnhance.php
+++ b/PluginEnhance.php
@@ -8,7 +8,7 @@ class PluginEnhance extends ServerPlugin
     public $features = [
         'packageName' => true,
         'testConnection' => true,
-        'showNameservers' => false,
+        'showNameservers' => true,
         'directlink' => true,
         'upgrades' => true
     ];


### PR DESCRIPTION
- Allow nameservers to be set within the admin panel, and allow the client to view these from the client area.
- Removed ability for Clientexec to update the PHP version of a website, as the server admin sets the default PHP version on the Package therefore it takes effect when created. Clientexec is currently overwriting this Enhance feature.

Both changes have been fully tested on my Clientexec instance.